### PR TITLE
Fix video cropping

### DIFF
--- a/BBMetalImage/BBMetalImage/BBMetalVideoWriter.swift
+++ b/BBMetalImage/BBMetalImage/BBMetalVideoWriter.swift
@@ -103,7 +103,7 @@ public class BBMetalVideoWriter {
         self.outputSettings = outputSettings
         
         let library = try! BBMetalDevice.sharedDevice.makeDefaultLibrary(bundle: Bundle.module)
-        let kernelFunction = library.makeFunction(name: "flipKernel")!
+        let kernelFunction = library.makeFunction(name: "yopeVideoWriterKernel")!
         computePipeline = try! BBMetalDevice.sharedDevice.makeComputePipelineState(function: kernelFunction)
         
         let descriptor = MTLTextureDescriptor()

--- a/BBMetalImage/BBMetalImage/Shaders/BBMetalYopeVideoWriter.metal
+++ b/BBMetalImage/BBMetalImage/Shaders/BBMetalYopeVideoWriter.metal
@@ -1,0 +1,30 @@
+#include <metal_stdlib>
+using namespace metal;
+
+kernel void yopeVideoWriterKernel(
+    texture2d<float, access::write> dst [[texture(0)]],
+    texture2d<float, access::sample> src [[texture(1)]],
+    constant bool &flipH [[buffer(0)]],
+    constant bool &flipV [[buffer(1)]],
+    uint2 gid [[thread_position_in_grid]]
+) {
+    uint dstW = dst.get_width();
+    uint dstH = dst.get_height();
+    if (gid.x >= dstW || gid.y >= dstH) return;
+
+    float2 uv = (float2(gid) + 0.5) / float2(dstW, dstH);
+
+    float srcW = src.get_width();
+    float srcH = src.get_height();
+    float2 suv = uv * float2(srcW, srcH);
+
+    if (flipH) suv.x = (srcW - 1.0) - suv.x;
+    if (flipV) suv.y = (srcH - 1.0) - suv.y;
+
+    constexpr sampler s(address::clamp_to_edge, filter::linear);
+
+    float2 suvNorm = (suv + 0.5) / float2(srcW, srcH);
+
+    float4 c = src.sample(s, suvNorm);
+    dst.write(c, gid);
+}


### PR DESCRIPTION
Added a combined shader for the video writing process that flips the front camera texture and rescales it to match the original frame size. Without this, if the sizes don't match, the resulting video gets cropped