### PR TITLE
Fix iOS availability for ultra-wide camera check

### DIFF
--- a/BBMetalImage/BBMetalImage/BBMetalCamera.swift
+++ b/BBMetalImage/BBMetalImage/BBMetalCamera.swift
@@ -318,7 +318,11 @@ public class BBMetalCamera: NSObject {
   }
 
   public var isUltraWideBackCameraSupported: Bool {
-    AVCaptureDevice.default(.builtInUltraWideCamera, for: .video, position: .back) != nil
+    if #available(iOS 13.0, *) {
+      return AVCaptureDevice.default(.builtInUltraWideCamera, for: .video, position: .back) != nil
+    } else {
+      return false
+    }
   }
 
   public var currentAbsoluteZoomFactor: CGFloat {


### PR DESCRIPTION
## Summary
Wrap `builtInUltraWideCamera` access with iOS 13 availability guard in `BBMetalCamera.isUltraWideBackCameraSupported`.

## Change
- on iOS 13+: return `AVCaptureDevice.default(.builtInUltraWideCamera, for: .video, position: .back) != nil`
- on older iOS: return `false`
